### PR TITLE
Add PreserveThreading=true to g0v slack

### DIFF
--- a/matterbridge.toml.template
+++ b/matterbridge.toml.template
@@ -2,6 +2,7 @@
 	[slack.g0v-tw]
 	Token="[% SLACK_G0V_TW_TOKEN %]"
 	RemoteNickFormat="[{BRIDGE}] @{NICK}"
+	PreserveThreading=true
 
 	[slack.code-for-korea]
 	Token="[% SLACK_CODE_FOR_KOREA_TOKEN %]"


### PR DESCRIPTION
According to https://github.com/42wim/matterbridge/issues/1558#issuecomment-1030712721 it seems that in order to sync thread between slack and discord, we need `PreserveThreading=true` on both Slack and Discord sides.

This PR tries adding the setting to see if it works.