### PR TITLE
Revert "Add PreserveThreading=true to g0v slack"

### DIFF
--- a/matterbridge.toml.template
+++ b/matterbridge.toml.template
@@ -2,7 +2,6 @@
 	[slack.g0v-tw]
 	Token="[% SLACK_G0V_TW_TOKEN %]"
 	RemoteNickFormat="[{BRIDGE}] @{NICK}"
-	PreserveThreading=true
 
 	[slack.code-for-korea]
 	Token="[% SLACK_CODE_FOR_KOREA_TOKEN %]"


### PR DESCRIPTION
Reverts g0v/bridge#4 because
- before merge, slack thread content can go to discord as replies
- after merge, discord would completely ignore all slack thread contents
 