### PR TITLE
Connect mygopen #mgpcofacts with g0v #cofacts

### DIFF
--- a/matterbridge.toml.template
+++ b/matterbridge.toml.template
@@ -24,6 +24,11 @@
 	Token="[% SLACK_TEST_TOKEN %]"
 	RemoteNickFormat="{NICK}@{BRIDGE}"
 
+	[slack.mygopen]
+	Token="[% SLACK_MYGOPEN_TOKEN %]"
+	RemoteNickFormat="{NICK}@{BRIDGE}"
+	PreserveThreading=true
+
 [mattermost]
 	[mattermost.g0v-xyz]
 	Server="chat.g0v.xyz:443"
@@ -132,6 +137,10 @@
 	[[gateway.inout]]
 	account="discord.cofacts"
 	channel="general"
+
+	[[gateway.inout]]
+	account="slack.mygopen"
+	channel="mgpcofacts"
 
 [[gateway]]
 	name="daodaoedu"


### PR DESCRIPTION
Cofacts are [currently trying](https://g0v.hackmd.io/kxGE_l7XT4ePTO1ljmtNkQ#Bridging-g0v-cofacts-to-other-fact-checking-orgs) to bridge #cofacts channel with professional fact checker's Slack, so that they can see latest updates in Cofacts channel right inside their working Slack.

In this PR we are connecting g0v #cofacts with [MyGoPen](https://www.mygopen.com/)'s slack.

